### PR TITLE
Show environment in workflow name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+run-name: CI (${{ github.event_name == 'workflow_dispatch' && github.event.inputs.env_type || 'local' }})
 
 on:
   push:
@@ -26,29 +27,14 @@ env:
 
 jobs:
 
-  # ---- Show ENV at top of workflow (summary, visible to everyone) ----
-  show-env-info:
-    runs-on: ubuntu-latest
-    name: "Show test environment"
-    steps:
-      - name: Display test environment info
-        run: |
-          echo "### Test environment: \`${{ env.ENV_TYPE }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "This environment will be used for all test jobs below."
-    outputs:
-      env_type: ${{ env.ENV_TYPE }}
-
   # ---- Chrome tests ----
   tests-chrome:
     name: ${{ matrix.testblock }} (Chrome)
-    needs: show-env-info
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'workflow_dispatch' ||
       github.event.inputs.browser == 'all' ||
       github.event.inputs.browser == 'chrome'
-    env:
-      ENV_TYPE: ${{ needs.show-env-info.outputs.env_type }}
     strategy:
       fail-fast: false
       matrix:
@@ -103,14 +89,11 @@ jobs:
   # ---- Opera tests ----
   tests-opera:
     name: ${{ matrix.testblock }} (Opera)
-    needs: show-env-info
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'workflow_dispatch' ||
       github.event.inputs.browser == 'all' ||
       github.event.inputs.browser == 'opera'
-    env:
-      ENV_TYPE: ${{ needs.show-env-info.outputs.env_type }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- show the selected environment in the workflow run name
- remove the `show-env-info` job

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_6840948b24ec832d9405b9dbb4cd0813