### PR TITLE
Fix CI env file step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose
 
+      - name: Prepare environment file
+        run: |
+          if [ "${ENV_TYPE}" = "staging" ]; then
+            echo "${{ secrets.LOCALCONF_STAGING_ENV }}" > localconf_staging.env
+          else
+            echo "${{ secrets.LOCALCONF_LOCAL_ENV }}" > localconf_local.env
+          fi
+
       - name: Show test context
         run: |
           echo "Running on ${{ matrix.testblock }} | Environment: $ENV_TYPE | Browser: chrome"
 
       - name: Run ${{ matrix.testblock }} tests (Chrome)
-        run: ./run_tests.sh -b chrome -m ${{ matrix.testblock }}
+        run: ./run_tests.sh -b chrome -m ${{ matrix.testblock }} -e $ENV_TYPE
 
       - name: Prepare report for GitHub Pages (Chrome)
         if: always()
@@ -112,12 +120,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose
 
+      - name: Prepare environment file
+        run: |
+          if [ "${ENV_TYPE}" = "staging" ]; then
+            echo "${{ secrets.LOCALCONF_STAGING_ENV }}" > localconf_staging.env
+          else
+            echo "${{ secrets.LOCALCONF_LOCAL_ENV }}" > localconf_local.env
+          fi
+
       - name: Show test context
         run: |
           echo "Running on ${{ matrix.testblock }} | Environment: $ENV_TYPE | Browser: opera"
 
       - name: Run ${{ matrix.testblock }} tests (Opera)
-        run: ./run_tests.sh -b opera -m ${{ matrix.testblock }}
+        run: ./run_tests.sh -b opera -m ${{ matrix.testblock }} -e $ENV_TYPE
 
       - name: Prepare report for GitHub Pages (Opera)
         if: always()


### PR DESCRIPTION
## Summary
- restore writing environment files from secrets
- pass ENV_TYPE to test runner

## Testing
- `pytest -k basic -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684098c705ec832d8a69f234c399828f