### PR TITLE
Fix CI run names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-run-name: CI (${{ github.event_name == 'workflow_dispatch' && github.event.inputs.env_type || 'local' }})
+run-name: ${{ github.event_name == 'push' && github.event.head_commit.message || github.event_name == 'schedule' && 'Cron CI' || format('CI ({0})', github.event.inputs.env_type || 'local') }}
 
 on:
   push:


### PR DESCRIPTION
## Summary
- show commit messages for push runs
- show `Cron CI` for scheduled runs
- keep environment info for manual runs

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest -q` *(fails: Required env var ADDRESS is not set, Selenium errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c3493367c832d9a0ae7b2e85bfbea