### PR TITLE
Fix gh-pages race in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,12 @@ jobs:
             cp tests/artifacts/*.png "$DIR/"
           fi
 
-      - name: Publish Chrome HTML report to GitHub Pages
+      - name: Upload Chrome report artifact
         if: always()
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
-          force: true
+          name: chrome-${{ matrix.testblock }}-report
+          path: out/chrome/${{ matrix.testblock }}
 
 
       - name: Show report URL (Chrome)
@@ -155,15 +152,12 @@ jobs:
             cp tests/artifacts/*.png "$DIR/"
           fi
 
-      - name: Publish Opera HTML report to GitHub Pages
+      - name: Upload Opera report artifact
         if: always()
-        uses: peaceiris/actions-gh-pages@v4
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
-          publish_branch: gh-pages
-          keep_files: true
-          force: true
+          name: opera-${{ matrix.testblock }}-report
+          path: out/opera/${{ matrix.testblock }}
 
 
       - name: Show report URL (Opera)
@@ -175,3 +169,31 @@ jobs:
         if: always()
         run: |
           echo "#### [${{ matrix.testblock }} (Opera)] Environment: \`${ENV_TYPE}\`" >> $GITHUB_STEP_SUMMARY
+
+  publish-reports:
+    name: Publish all reports to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [tests-chrome, tests-opera]
+    if: always()
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: out
+          merge-multiple: true
+
+      - name: Publish HTML reports
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          publish_branch: gh-pages
+          keep_files: true
+          force: true
+
+      - name: Show report URLs
+        run: |
+          for p in $(find out -mindepth 2 -maxdepth 2 -type d); do
+            rel=${p#out/}
+            echo "::notice title=Report URL::https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/$rel/"
+          done

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 - minor code cleaning
 - better ci names
 - fixed GitHub Pages publishing so all reports persist
+- sequential GH Pages upload to avoid push conflicts
 
 
 ## [0.8.1]


### PR DESCRIPTION
## Summary
- collect reports from matrix jobs with upload-artifact
- publish results in a single job after tests finish
- document new CI fix in the changelog

## Testing
- `pre-commit run --files .github/workflows/ci.yml Changelog.md`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_684db1826bbc832da435b05fcf103a8f