### PR TITLE
Link skips and xfails with bug numbers

### DIFF
--- a/tests/api/test_basic_api_login_tests.py
+++ b/tests/api/test_basic_api_login_tests.py
@@ -16,7 +16,7 @@ from utils.markers import api
             "wrongpass",
             HTTPStatus.UNAUTHORIZED,
             marks=pytest.mark.xfail(
-                reason="BUG: API returns 404 for invalid login instead of 401. See BUGS.md #1"
+                reason="BUG no. 1: API returns 404 for invalid login instead of 401"
             ),
         ),
         (None, "any", HTTPStatus.BAD_REQUEST),
@@ -24,5 +24,7 @@ from utils.markers import api
     ],
 )
 def test_verify_login_cases(email, password, expected_code, user_api):
+    """Verify various login scenarios via the public API."""
+
     resp = call_verify_login(email, password, user_api)
     assert resp.json().get("responseCode") == expected_code

--- a/tests/api/test_user_profile_api.py
+++ b/tests/api/test_user_profile_api.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 @api
 @usertests
 def test_create_delete_account():
+    """Create a user, delete it, then verify the account no longer exists."""
+
     user = user_create_payload()
     req = create_account(user)
     assert req.json().get("responseCode") == HTTPStatus.CREATED
@@ -26,4 +28,6 @@ def test_create_delete_account():
 @api
 @usertests
 def test_create_account_with_fixture(user_api):
+    """Placeholder for testing account creation using a fixture."""
+
     pass

--- a/tests/ui/test_cart.py
+++ b/tests/ui/test_cart.py
@@ -10,6 +10,8 @@ from utils.markers import cart, ui
 @ui
 @cart
 def test_add_single_product(driver_on_address):
+    """Add a single product from the main page and verify it appears in the cart."""
+
     prod = add_from_main(driver_on_address, idx=0)
     cart = open_cart(driver_on_address)
     assert_cart_all(cart, [(prod.name, prod.qty, prod.price)])
@@ -18,6 +20,8 @@ def test_add_single_product(driver_on_address):
 @ui
 @cart
 def test_add_two_products(driver_on_address):
+    """Add two different products from the main page and verify both are listed."""
+
     prod1 = add_from_main(driver_on_address, idx=0)
     prod2 = add_from_main(driver_on_address, idx=1)
     cart = open_cart(driver_on_address)
@@ -78,6 +82,8 @@ def test_add_different_products_main_and_details(driver_on_address):
 @ui
 @cart
 def test_add_multiple_products_from_details(driver_on_address):
+    """Add multiple products via the details pages and confirm the cart summary."""
+
     prod1 = add_from_details(driver_on_address, idx=1, qty=2, back_to_main=True)
     prod2 = add_from_details(driver_on_address, idx=2, qty=5, back_to_main=True)
     cart = open_cart(driver_on_address)
@@ -96,7 +102,7 @@ def test_add_multiple_products_from_details(driver_on_address):
         pytest.param(
             int(1e100),
             marks=pytest.mark.xfail(
-                reason="BUG: Input field allows absurdly large quantity (>3 chars), see BUGS.md"
+                reason="BUG no. 7: Input field allows absurdly large quantity (>3 chars)"
             ),
             id="googol",
         ),
@@ -131,7 +137,7 @@ def test_cart_quantity_editable(driver_on_address):
     Currently skipped due to product input field in cart being non-editable.
     """
 
-    pytest.skip(reason="See BUGS.md: Cart Quantity Modification Not Working.")
+    pytest.skip(reason="BUG no. 3: Cart Quantity Modification Not Working.")
     # Example for future implementation (once bug is fixed):
     # prod = add_from_main(driver_on_address, idx=0)
     # cart = open_cart(driver_on_address)
@@ -152,7 +158,7 @@ def test_cart_product_image_redirects_to_details(driver_on_address):
     Currently skipped until feature is implemented.
     """
 
-    pytest.skip("See BUGS.md: Product image in cart does not redirect to details page.")
+    pytest.skip(reason="BUG no. 4: Product image in cart does not redirect to details page.")
 
     # Example for future implementation:
     # prod = add_from_main(driver_on_address, idx=0)

--- a/tests/ui/test_product_details.py
+++ b/tests/ui/test_product_details.py
@@ -14,24 +14,24 @@ from utils.markers import product_details, ui
         pytest.param(
             "12abc",
             marks=pytest.mark.xfail(
-                reason="BUG: accepts mixed string '12abc' as quantity"
+                reason="BUG no. 7: accepts mixed string '12abc' as quantity"
             ),
             id="mixed_string",
         ),
         pytest.param("!", id="symbol"),
         pytest.param(
             "-5",
-            marks=pytest.mark.xfail(reason="BUG: accepts negative numbers"),
+            marks=pytest.mark.xfail(reason="BUG no. 7: accepts negative numbers"),
             id="negative",
         ),
         pytest.param(
             "3.5",
-            marks=pytest.mark.xfail(reason="BUG: accepts float as quantity"),
+            marks=pytest.mark.xfail(reason="BUG no. 7: accepts float as quantity"),
             id="float",
         ),
         pytest.param(
             "  7   ",
-            marks=pytest.mark.xfail(reason="BUG: accepts padded string as quantity"),
+            marks=pytest.mark.xfail(reason="BUG no. 7: accepts padded string as quantity"),
             id="whitespace",
         ),
     ],

--- a/tests/ui/test_user_profile_ui.py
+++ b/tests/ui/test_user_profile_ui.py
@@ -11,6 +11,8 @@ from utils.markers import usertests
 @usertests
 @pytest.mark.parametrize("user_api", [False], indirect=True)  # fixture parametrization
 def test_delete_account_via_ui_and_verify_api(driver, user_api):
+    """Delete an account through the UI and verify via API that it was removed."""
+
     login_page = LoginPage(driver)
     login_page.load()
     login_page.login(user_api.email, user_api.password)


### PR DESCRIPTION
## Summary
- reference BUG ids for xfail markers in product quantity tests
- add bug numbers to cart test skips
- update API login xfail to reference BUG 1
- document the purpose of each test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, Selenium setup, and connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686681973ec4832dad4585643cd6ead4