### PR TITLE
build(grid-slots): allow more parallel sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ environment).
 * The script runs `docker compose up -d <service>` to start the necessary Selenium service:
 
   * **Chrome:** `selenium-chrome` (headless) or `selenium-chrome-debug` (with VNC).
+  * Chrome and Opera services expose 5 parallel slots to accommodate concurrent test runs.
   * **Opera:** `selenium-opera` or `selenium-opera-debug`.
 * **What happens under the hood?**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   selenium-chrome:
     image: selenium/standalone-chrome:latest
     container_name: selenium-chrome
+    environment:
+      SE_NODE_MAX_SESSIONS: "5"
+      SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     ports:
       - "4444:4444"
 
@@ -15,6 +18,8 @@ services:
       SCREEN_WIDTH: 2560
       SCREEN_HEIGHT: 1440
       SCREEN_DEPTH: 24
+      SE_NODE_MAX_SESSIONS: "5"
+      SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     ports:
       - "4445:4444"
       - "5900:5900"
@@ -26,6 +31,8 @@ services:
       - ./tools/operadriver:/usr/local/bin/opera-driver
     environment:
       SE_OPERA_DRIVER_EXECUTABLE: /usr/local/bin/opera-driver
+      SE_NODE_MAX_SESSIONS: "5"
+      SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     ports:
       - "4448:4444"
 
@@ -41,6 +48,8 @@ services:
       SCREEN_HEIGHT: 1440
       SCREEN_DEPTH: 24
       SE_OPERA_DRIVER_EXECUTABLE: /usr/local/bin/opera-driver
+      SE_NODE_MAX_SESSIONS: "5"
+      SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     ports:
       - "4449:4444"
       - "5902:5900"


### PR DESCRIPTION
## Summary
- increase Chrome and Opera slots in selenium grid to 5 for both headless and debug services
- document additional Chrome and Opera capacity in README

## Testing
- `pre-commit run --files docker-compose.yml README.md`
- `PYTHONPATH=. pytest -q` *(fails: RuntimeError: Required env var ADDRESS is not set; AttributeError: 'NoneType' object has no attribute 'execute')*

------
https://chatgpt.com/codex/tasks/task_e_68a860d4ba40832d899aa76779045d88